### PR TITLE
Fix pos_constr_comma Trail

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3110,6 +3110,12 @@ void newlines_class_colon_pos(c_token_t tok)
                   {
                      newline_add_after(pc);
                   }
+                  prev = chunk_get_prev_nc(pc);
+                  if (chunk_is_newline(prev) && chunk_safe_to_del_nl(prev))
+                  {
+                      chunk_del(prev);
+                      MARK_CHANGE();
+                  }
                }
                else if (pcc & TP_LEAD)
                {


### PR DESCRIPTION
When `pos_constr_comma` is set to `Trail`, leading commas are not properly handled: preceding new lines is not removed, but a following newline is added. This results in having commas in their own lines.

Input:

```
MyClass::MyClass(Type *var1, Type *var2) :
    MySuperClass(parent)
  , mVar1(var1)
  , mVar2(var2) {
}
```

Output:

```
MyClass::MyClass(Type *var1, Type *var2) :
    MySuperClass(parent)
    ,
    mVar1(var1)
    ,
    mVar2(var2) {
}
```

Expected:

```
MyClass::MyClass(Type *var1, Type *var2) :
    MySuperClass(parent),
    mVar1(var1),
    mVar2(var2) {
}
```

This patch fixes this behaviour.
