### PR TITLE
Fix pos_constr_comma Trail

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3367,6 +3367,12 @@ void newlines_class_colon_pos(c_token_t tok)
                   {
                      newline_add_after(pc);
                   }
+                  prev = chunk_get_prev_nc(pc);
+                  if (chunk_is_newline(prev) && chunk_safe_to_del_nl(prev))
+                  {
+                      chunk_del(prev);
+                      MARK_CHANGE();
+                  }
                }
                else if (pcc & TP_LEAD)
                {

--- a/tests/config/initlist_leading_commas.cfg
+++ b/tests/config/initlist_leading_commas.cfg
@@ -1,0 +1,3 @@
+indent_columns 4
+nl_constr_init_args Force
+pos_constr_comma Trail

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -286,3 +286,7 @@
 33048 bug_i_405.cfg                    cpp/bug_i_405.cpp
 33049 pp-pragma.cfg                    cpp/pp-pragma.cpp
 33051 empty.cfg                        cpp/bug_i_503.cpp
+
+
+
+50000 initlist_leading_commas.cfg      cpp/initlist_leading_commas.cpp

--- a/tests/input/cpp/initlist_leading_commas.cpp
+++ b/tests/input/cpp/initlist_leading_commas.cpp
@@ -1,0 +1,5 @@
+MyClass::MyClass(Type *var1, Type *var2) :
+    BaseClass(parent)
+  , mVar1(var1)
+  , mVar2(var2) {
+}

--- a/tests/output/cpp/50000-initlist_leading_commas.cpp
+++ b/tests/output/cpp/50000-initlist_leading_commas.cpp
@@ -1,0 +1,5 @@
+MyClass::MyClass(Type *var1, Type *var2) :
+    BaseClass(parent),
+    mVar1(var1),
+    mVar2(var2) {
+}


### PR DESCRIPTION
**Reopening a PR for merge on `genymobile` instead of `master`.**

When `pos_constr_comma` is set to `Trail`, leading commas are not properly handled: preceding new lines is not removed, but a following newline is added. This results in having commas in their own lines.

Input:

```
MyClass::MyClass(Type *var1, Type *var2) :
    MySuperClass(parent)
  , mVar1(var1)
  , mVar2(var2) {
}
```

Output:

```
MyClass::MyClass(Type *var1, Type *var2) :
    MySuperClass(parent)
    ,
    mVar1(var1)
    ,
    mVar2(var2) {
}
```

Expected:

```
MyClass::MyClass(Type *var1, Type *var2) :
    MySuperClass(parent),
    mVar1(var1),
    mVar2(var2) {
}
```

This patch fixes this behaviour.
