### PR TITLE
Support macro functions which do not need a semicolon at the end

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ add_executable(uncrustify
   src/lang_pawn.cpp
   src/logger.cpp
   src/logmask.cpp
+  src/macro_func_nosm.cpp
   src/md5.cpp
   src/newlines.cpp
   src/options.cpp

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1790,3 +1790,6 @@ use_indent_continue_only_once             = false    # false/true
 #
 # option(s) with 'not default' value: 0
 #
+# You can mark some macro functions as not requiring an ending semi-colon.
+# Example:
+# macro-func-nosm Q_DISABLE_COPY

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -11,6 +11,7 @@
 #include "char_table.h"
 #include "prototypes.h"
 #include "chunk_list.h"
+#include "macro_func_nosm.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -589,6 +590,21 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
    else if (patcls == PATCLS_ELSE)
    {
       push_fmr_pse(frm, pc, BS_ELSEIF, "+ComplexElse");
+   }
+
+   /* Check if we are at the end of a macro function which does not require
+    * an ending semi-colon.
+    * If we are, mark the end of the statement.
+    */
+   if (pc->type == CT_PAREN_CLOSE) {
+      prev = chunk_get_prev_type(pc, CT_PAREN_OPEN, pc->level);
+      if (prev) {
+         prev = chunk_get_prev_ncnl(prev);
+      }
+      if (prev && prev->type == CT_MACRO_FUNC && is_macro_func_nosm(prev->text())) {
+         frm->stmt_count = 0;
+         frm->expr_count = 0;
+      }
    }
 
    /* Mark simple statement/expression starts

--- a/src/macro_func_nosm.cpp
+++ b/src/macro_func_nosm.cpp
@@ -1,0 +1,18 @@
+#include "macro_func_nosm.h"
+
+#include <set>
+#include <string>
+
+using namespace std;
+typedef set<string> stringset;
+static stringset macro_func_nosm;
+
+void add_macro_func_nosm(const char *name)
+{
+   macro_func_nosm.insert(name);
+}
+
+bool is_macro_func_nosm(const char *name)
+{
+   return macro_func_nosm.find(name) != macro_func_nosm.end();
+}

--- a/src/macro_func_nosm.h
+++ b/src/macro_func_nosm.h
@@ -1,0 +1,15 @@
+#ifndef MACRO_FUNC_NOSM_H
+#define MACRO_FUNC_NOSM_H
+
+/**
+ * Adds a macro function which does not require an ending semi-colon
+ */
+void add_macro_func_nosm(const char *name);
+
+/**
+ * Returns true if name is a macro function which does not require an ending
+ * semi-colon
+ */
+bool is_macro_func_nosm(const char *name);
+
+#endif // MACRO_FUNC_NOSM_H

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -11,6 +11,7 @@
 #include "args.h"
 #include "prototypes.h"
 #include "uncrustify_version.h"
+#include "macro_func_nosm.h"
 #include <cstring>
 #ifdef HAVE_STRINGS_H
 #include <strings.h>  /* strcasecmp() */
@@ -1778,6 +1779,11 @@ int load_option_file(const char *filename)
       else if (strcasecmp(args[0], "macro-else") == 0)
       {
          add_keyword(args[1], CT_MACRO_ELSE);
+      }
+      else if (strcasecmp(args[0], "macro-func-nosm") == 0)
+      {
+         add_keyword(args[1], CT_MACRO_FUNC);
+         add_macro_func_nosm(args[1]);
       }
       else if (strcasecmp(args[0], "set") == 0)
       {

--- a/tests/config/macro_func_nosm.cfg
+++ b/tests/config/macro_func_nosm.cfg
@@ -1,0 +1,16 @@
+# Declare Q_DISABLE_COPY as a macro function which does not require an ending
+# semicolon so that when the uncrustify parses this:
+#
+#  Q_DISABLE_COPY(Foo)
+#  Bar* mBar;
+#
+# It does not consider the `*` as a multiplication operator.
+macro-func-nosm Q_DISABLE_COPY
+
+indent_columns 4
+indent_with_tabs 0
+indent_class True
+
+sp_before_ptr_star Remove
+sp_after_ptr_star Force
+sp_arith Force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -290,3 +290,4 @@
 
 
 50000 initlist_leading_commas.cfg      cpp/initlist_leading_commas.cpp
+50001 macro_func_nosm.cfg              cpp/macro_func_nosm.cpp

--- a/tests/input/cpp/macro_func_nosm.cpp
+++ b/tests/input/cpp/macro_func_nosm.cpp
@@ -1,0 +1,11 @@
+class Foo
+{
+public:
+    Foo() {
+        int i = 2+2;
+    };
+
+private:
+    Q_DISABLE_COPY(Foo)
+    Bar * mBar;
+};

--- a/tests/output/cpp/50001-macro_func_nosm.cpp
+++ b/tests/output/cpp/50001-macro_func_nosm.cpp
@@ -1,0 +1,11 @@
+class Foo
+{
+public:
+    Foo() {
+        int i = 2 + 2;
+    };
+
+private:
+    Q_DISABLE_COPY(Foo)
+    Bar* mBar;
+};


### PR DESCRIPTION
Some macros declare the statement ending semicolon themselves. For example the
Qt library declares the Q_DISABLE_COPY macro like this:

```
#define Q_DISABLE_COPY(Class) \
    Class(const Class &) Q_DECL_EQ_DELETE;\
    Class &operator=(const Class &) Q_DECL_EQ_DELETE;
```

When used like this:

```
class Foo {
private:
    Q_DISABLE_COPY(Foo)
    Bar* bar;
};
```

uncrustify parser is confused and interprets the `*` as an arithmetic operator.

This patch adds a new option: `macro-func-nosm` which makes it possible to
declare some macros as not requiring an ending semicolon.
